### PR TITLE
Update IRFGameId for 'Papers, Please!'

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -15,7 +15,7 @@ import { CustomClient } from './typings/Extensions.js';
 //#region Enums
 enum IRFGameId {
   'Global' = 0,
-  'Papers, Please!' = 583507031,
+  'Papers, Please!' = 95198857650727,
   'Sevastopol Military Academy' = 603943201,
   'Triumphal Arch of Moscow' = 2506054725,
   'Tank Training Grounds' = 2451182763,


### PR DESCRIPTION
The game has been moved and bans are now stored under game ID 95198857650727. Because of this, it is no longer possible to remove bans using the old place ID through the current unban command.

Since bans associated with the old game ID are no longer working, keeping the old place ID in the array doesn't appear necessary. The unban command retrieves its data from this array, so updating it to use the new game ID is required for the unban system to work with newly issued bans.

<img width="385" height="587" alt="image" src="https://github.com/user-attachments/assets/3695b140-204f-4eb0-beb8-5e962a73a7d2" />

<img width="604" height="451" alt="image" src="https://github.com/user-attachments/assets/7b1b3bac-ae0d-4769-8913-84056abfdb33" />
